### PR TITLE
Backwards-compatible env support; fail-safe production stage detection

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -2,13 +2,17 @@
 
 class Logger {
   constructor() {
-    this.isProduction = process.env.stage === 'prod';
+    var effectiveStage = process.env.stage || process.env.STAGE
+    
+    this.isProduction = effectiveStage.toLowerCase().startsWith('prod');
     this.logLevelMap = { debug: 3, info: 2, error: 1 };
     this.logLevel = this.setLogLevel();
   }
 
   setLogLevel() {
-    return this.logLevelMap[process.env.logLevel];
+    var effectiveLogLevel = process.env.logLevel || process.env.LOG_LEVEL
+
+    return this.logLevelMap[effectiveLogLevel];
   }
 
   debug(...message) {
@@ -16,7 +20,7 @@ class Logger {
       return;
     }
     console.debug(
-      `${process.env.stackName.toUpperCase()}: ${JSON.stringify(message)}`,
+      `${process.env.stackName.toUpperCase()}: ${JSON.stringify(message)}`
     );
   }
 
@@ -32,7 +36,7 @@ class Logger {
       return;
     }
     console.info(
-      `${process.env.stackName.toUpperCase()}: ${JSON.stringify(message)}`,
+      `${process.env.stackName.toUpperCase()}: ${JSON.stringify(message)}`
     );
   }
 
@@ -44,14 +48,14 @@ class Logger {
       console.error(message);
     } else {
       console.error(
-        `${process.env.stackName.toUpperCase()}: ${JSON.stringify(message)}`,
+        `${process.env.stackName.toUpperCase()}: ${JSON.stringify(message)}`
       );
     }
   }
 
   audit(...message) {
     console.log(
-      `${process.env.stackName.toUpperCase()}: ${JSON.stringify(message)}`,
+      `${process.env.stackName.toUpperCase()}: ${JSON.stringify(message)}`
     );
   }
 
@@ -60,7 +64,7 @@ class Logger {
       return;
     }
     console.log(
-      `${process.env.stackName.toUpperCase()}: ${JSON.stringify(message)}`,
+      `${process.env.stackName.toUpperCase()}: ${JSON.stringify(message)}`
     );
   }
 }


### PR DESCRIPTION
Use of variables to check both possible environment variable names should allow this to work with previous AND current projects that use ls-lambda-helpers.

Additionally, the isProduction check should now detect variants of "prod" like "Prod", "production", and "Production"; false positives and withholding logging is better than false negatives and logging potentially sensitive information.

Also removed some superfluous commas.